### PR TITLE
Add/Delete, GotoSelected, Preview AFS

### DIFF
--- a/ShadowFNT/Structures/FNT.cs
+++ b/ShadowFNT/Structures/FNT.cs
@@ -107,6 +107,12 @@ namespace ShadowFNT.Structures {
             for (int i = 0; i < entryTable.Count; i++)
                 Encoding.Unicode.GetBytes(entryTable[i].subtitle).ToList().ForEach(b => { fntFile.Add(b); });
 
+            // add 4 null bytes to satisfy in-game parser's constraint to close file of any size
+            fntFile.Add(0x00);
+            fntFile.Add(0x00);
+            fntFile.Add(0x00);
+            fntFile.Add(0x00);
+
             return fntFile;
         }
 
@@ -317,12 +323,12 @@ namespace ShadowFNT.Structures {
                 entryTable[i] = succeedingEntry;
             }
 
-           /* //shrink an entry size for all
+           //shrink an entry size for all
             for (int i = 0; i < entryTable.Count; i++) {
                 TableEntry entry = entryTable[i];
                 entry.subtitleAddress -= ENTRY_SIZE;
                 entryTable[i] = entry;
-            }*/
+            }
         }
     }
 }

--- a/ShadowFNT/Structures/FNT.cs
+++ b/ShadowFNT/Structures/FNT.cs
@@ -15,11 +15,12 @@ namespace ShadowFNT.Structures {
         list of UTF-16 Strings (Note: for convenience and eq(), sticking Strings inside TableEntry, but will be written per original file)
     }
     */
+
     public struct FNT {
         public String fileName;
         public String filterString;
-        public int numberOfEntries;
         public List<TableEntry> entryTable;
+        private const int ENTRY_SIZE = 20;
 
         public FNT(String fileName, ref byte[] file) {
             this = ParseFNTFile(fileName, ref file);
@@ -39,7 +40,7 @@ namespace ShadowFNT.Structures {
             fnt.fileName = fileName;
             fnt.filterString = filterString;
 
-            fnt.numberOfEntries = BitConverter.ToInt32(file, 0);
+            int numberOfEntries = BitConverter.ToInt32(file, 0);
             int positionIndex = 4; // position of byte to read
 
             fnt.entryTable = new List<TableEntry>();
@@ -48,7 +49,7 @@ namespace ShadowFNT.Structures {
             int subtitleTableEntryStructSize = 0x14;
 
             // read table entries
-            for (int i = 0; i < fnt.numberOfEntries; i++) {
+            for (int i = 0; i < numberOfEntries; i++) {
                 TableEntry entry = new TableEntry {
                     subtitleAddress = BitConverter.ToInt32(file, positionIndex),
                     messageIdBranchSequence = BitConverter.ToInt32(file, positionIndex + 4),
@@ -62,10 +63,10 @@ namespace ShadowFNT.Structures {
             }
 
             // read UTF-16 strings
-            for (int i = 0; i < fnt.numberOfEntries; i++) {
+            for (int i = 0; i < numberOfEntries; i++) {
                 int subtitleLength;
                 String subtitle;
-                if (i == fnt.entryTable.Count - 1) {
+                if (i == numberOfEntries - 1) {
                     // if last subtitleTable entry, size is originalFilesize - entry index
                     // however the original .fnt files sometimes have junk strings at the end
                     // end at first "\0"
@@ -90,10 +91,11 @@ namespace ShadowFNT.Structures {
             List<byte> fntFile = new List<byte>();
 
             // write header
-            BitConverter.GetBytes(this.numberOfEntries).ToList().ForEach(b => { fntFile.Add(b); });
+            BitConverter.GetBytes(entryTable.Count).ToList().ForEach(b => { fntFile.Add(b); });
 
             // write table entries
-            for (int i = 0; i < numberOfEntries; i++) {
+            for (int i = 0; i < entryTable.Count; i++) {
+                
                 BitConverter.GetBytes(entryTable[i].subtitleAddress).ToList().ForEach(b => { fntFile.Add(b); });
                 BitConverter.GetBytes(entryTable[i].messageIdBranchSequence).ToList().ForEach(b => { fntFile.Add(b); });
                 BitConverter.GetBytes((int)entryTable[i].entryType).ToList().ForEach(b => { fntFile.Add(b); });
@@ -102,7 +104,7 @@ namespace ShadowFNT.Structures {
             }
 
             // write UTF-16 entries
-            for (int i = 0; i < numberOfEntries; i++)
+            for (int i = 0; i < entryTable.Count; i++)
                 Encoding.Unicode.GetBytes(entryTable[i].subtitle).ToList().ForEach(b => { fntFile.Add(b); });
 
             return fntFile;
@@ -295,7 +297,32 @@ namespace ShadowFNT.Structures {
                 succeedingEntry.subtitleAddress = entryTable[i].subtitleAddress + 2;
                 entryTable[i] = succeedingEntry;
             }
+
+            //grow an entry size for all
+            for (int i = 0; i < entryTable.Count; i++) {
+                 TableEntry entry = entryTable[i];
+                 entry.subtitleAddress += ENTRY_SIZE;
+                 entryTable[i] = entry;
+             }
             return 0;
+        }
+
+        public void DeleteEntry(int index) {
+            int chardiff = entryTable[index].subtitle.Length * 2; //successor's address - original entry is difference
+            entryTable.RemoveAt(index);
+            //correct subtitleAddress for all succeeding entries (start at self since successor occupies old location)
+            for (int i = index; i < entryTable.Count; i++) {
+                TableEntry succeedingEntry = entryTable[i];
+                succeedingEntry.subtitleAddress -= chardiff;
+                entryTable[i] = succeedingEntry;
+            }
+
+           /* //shrink an entry size for all
+            for (int i = 0; i < entryTable.Count; i++) {
+                TableEntry entry = entryTable[i];
+                entry.subtitleAddress -= ENTRY_SIZE;
+                entryTable[i] = entry;
+            }*/
         }
     }
 }

--- a/ShadowTH Text Editor/MainWindow.xaml
+++ b/ShadowTH Text Editor/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:ShadowTH_Text_Editor"
         mc:Ignorable="d"
-        Title="Shadow The Hedgehog Text Editor / FNT Editor" Height="720" Width="900" MinWidth="900" MinHeight="720" MaxHeight="720" MaxWidth="900" Icon="ShadowFNT.ico" ResizeMode="CanMinimize">
+        Title="Shadow The Hedgehog Text Editor / FNT Editor v1.4" Height="720" Width="900" MinWidth="900" MinHeight="720" MaxHeight="720" MaxWidth="900" Icon="ShadowFNT.ico" ResizeMode="CanMinimize">
     <Grid x:Name="mainGridPanel">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="16*"/>
@@ -96,12 +96,15 @@
                 <Button x:Name="Button_About" Margin="220,-30,0,0" Height="30" Click="Button_About_Click" Width="65">About</Button>
             </StackPanel>
         </GroupBox>
-        <GroupBox Header="Add New Entry" Margin="166,595,327,10" Grid.Column="2" Grid.ColumnSpan="2">
+        <GroupBox Header="Entry Controls" Margin="166,595,327,10" Grid.Column="2" Grid.ColumnSpan="2">
             <StackPanel>
-                <TextBlock Margin="10,0,0,0">Message ID / Branch / Sequence</TextBlock>
-                <TextBox x:Name="TextBox_AddEntryMessageID" Margin="30,10,150,0"  Width="125" Height="15" TextChanged="TextBox_AddEntryMessageID_TextChanged"/>
-                <Button x:Name="AddEntry_Button" Margin="100,-22,0,0" IsEnabled="False" Width="65" Height="30" Content="Add Entry" Click="AddEntry_Button_Click"/>
-                <Button x:Name="AddEntry_Question_Button" Margin="200,-30,0,0" Width="25" Height="30" Content="?" Click="AddEntry_Question_Button_Click"/>
+                <Grid Margin="0,5,0,-3">
+                    <TextBlock x:Name ="TextBlock_AddEntryHint" Margin="6,2,0,0"  Foreground="Gray" Text="Message ID / Branch / Sequence" />
+                    <TextBox x:Name="TextBox_AddEntryMessageID" Background="Transparent" VerticalContentAlignment="Center" Margin="0,0,130,0"  Width="175" Height="20" TextChanged="TextBox_AddEntryMessageID_TextChanged"/>
+                </Grid>
+                <Button x:Name="Button_AddEntry" Margin="120,-22,0,0" IsEnabled="False" Width="65" Height="30" Content="Add Entry" Click="Button_AddEntry_Click"/>
+                <Button x:Name="Button_AddEntry_Question" Margin="220,-30,0,0" Width="25" Height="30" Content="?" Click="Button_AddEntry_Question_Click"/>
+                <Button x:Name="Button_DeleteEntry" Margin="-185,0,0,0" IsEnabled="False" Width="120" Height="20" Content="Delete Selected Entry" Click="Button_DeleteEntry_Click"/>
             </StackPanel>
         </GroupBox>
     </Grid>

--- a/ShadowTH Text Editor/MainWindow.xaml
+++ b/ShadowTH Text Editor/MainWindow.xaml
@@ -79,14 +79,18 @@
         </GroupBox>
         <GroupBox Header="Search Filters" Margin="10,10,325,530" Padding="10" Grid.ColumnSpan="4">
             <StackPanel Orientation="Vertical" Margin="0,0,0,0"  Height="104" Width="515">
-                <StackPanel>
-                    <TextBlock><Run Text="Search for Subtitle Text"/></TextBlock>
-                    <TextBox x:Name="TextBox_SearchText" AcceptsReturn="True" HorizontalAlignment="Left" VerticalContentAlignment="Center" Text="" TextWrapping="Wrap" TextChanged="TextBox_SearchFilters_TextChanged" Margin="0,0,0,10" Height="25" Width="515"/>
+                    <StackPanel>
+                        <TextBlock><Run Text="Search for Subtitle Text"/></TextBlock>
+                        <TextBox x:Name="TextBox_SearchText" AcceptsReturn="True" HorizontalAlignment="Left" VerticalContentAlignment="Center" Text="" TextWrapping="Wrap" TextChanged="TextBox_SearchFilters_TextChanged" Margin="0,0,0,10" Height="25" Width="420"/>
+                    </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <StackPanel>
+                        <TextBlock><Run Text="Search for Audio Filename"/></TextBlock>
+                        <TextBox x:Name="TextBox_SearchAudioFileName" AcceptsReturn="True" HorizontalAlignment="Left" VerticalContentAlignment="Center" Text="" TextWrapping="Wrap" TextChanged="TextBox_SearchFilters_TextChanged" Height="25" Width="186"/>
+                    </StackPanel>
+                    <Button x:Name="Button_GotoSelected" Margin="240,20,0,0" IsEnabled="False" Width="85" Height="25" Content="Goto Selected" Click="Button_GotoSelected_Click"/>
                 </StackPanel>
-                <StackPanel>
-                    <TextBlock><Run Text="Search for Audio Filename"/></TextBlock>
-                    <TextBox x:Name="TextBox_SearchAudioFileName" AcceptsReturn="True" HorizontalAlignment="Left" VerticalContentAlignment="Center" Text="" TextWrapping="Wrap" TextChanged="TextBox_SearchFilters_TextChanged" Height="25" Width="515"/>
-                </StackPanel>
+
             </StackPanel>
         </GroupBox>
         <GroupBox Header="Program Controls" Margin="175,595,10,10" Grid.Column="3">

--- a/ShadowTH Text Editor/MainWindow.xaml
+++ b/ShadowTH Text Editor/MainWindow.xaml
@@ -68,8 +68,9 @@
                 <TextBlock>Audio Filename</TextBlock>
                 <TextBlock x:Name="TextBlock_AfsAudioIDName" Margin="0,5,0,10"/>
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                    <Button x:Name="Button_ReplaceADX" IsEnabled="False" Margin="0,0,10,0" Width="125" Height="30" HorizontalAlignment="Left" VerticalAlignment="Top" Click="Button_ReplaceADXClick" Content="Replace ADX"/>
-                    <Button x:Name="Button_ExtractADX" IsEnabled="False" Margin="10,0,0,0" Width="125" Height="30" HorizontalAlignment="Left" VerticalAlignment="Top" Click="Button_ExtractADXClick" Content="Extract ADX"/>
+                    <Button x:Name="Button_ReplaceADX" IsEnabled="False" Margin="0,0,10,0" Width="100" Height="30" HorizontalAlignment="Left" VerticalAlignment="Top" Click="Button_ReplaceADXClick" Content="Replace ADX"/>
+                    <Button x:Name="Button_ExtractADX" IsEnabled="False" Margin="10,0,0,0" Width="100" Height="30" HorizontalAlignment="Left" VerticalAlignment="Top" Click="Button_ExtractADXClick" Content="Extract ADX"/>
+                    <Button x:Name="Button_PreviewADX" FontSize="20" IsEnabled="False" Margin="20,0,0,0" Width="30" Height="30" HorizontalAlignment="Left" VerticalAlignment="Top" Click="Button_PreviewADXClick" Content="►"/>
                 </StackPanel>
                 <TextBlock>Text</TextBlock>
                 <TextBox x:Name="TextBox_EditSubtitle" TextWrapping="Wrap" AcceptsReturn="True" Height="70"/>

--- a/ShadowTH Text Editor/MainWindow.xaml.cs
+++ b/ShadowTH Text Editor/MainWindow.xaml.cs
@@ -76,6 +76,7 @@ namespace ShadowTH_Text_Editor {
             TextBox_AudioID.Clear();
             TextBox_SubtitleActiveTime.Clear();
             Button_DeleteEntry.IsEnabled = false;
+            Button_GotoSelected.IsEnabled = false;
         }
 
         private void ListBox_OpenedFNTS_SelectionChanged(object sender, SelectionChangedEventArgs e) {
@@ -104,6 +105,7 @@ namespace ShadowTH_Text_Editor {
                 return;
             }
             Button_DeleteEntry.IsEnabled = true;
+            Button_GotoSelected.IsEnabled = true;
             var audioID = currentFnt.GetEntryAudioID(currentSubtitleIndex);
 
             TextBlock_SubtitleAddress.Text = currentFnt.GetEntrySubtitleAddress(currentSubtitleIndex).ToString();
@@ -341,6 +343,14 @@ namespace ShadowTH_Text_Editor {
             ListBox_CurrentFNT.SelectedIndex = -1;
             UpdateDisplayTableListView();
             Button_ExportChangedFNTs.IsEnabled = true;
+        }
+
+        private void Button_GotoSelected_Click(object sender, RoutedEventArgs e) {
+            TableEntry entry = (TableEntry)ListBox_CurrentFNT.SelectedItem;
+            TextBox_SearchText.Text = "";
+            TextBox_SearchAudioFileName.Text = "";
+            UpdateDisplayTableListView();
+            ListBox_CurrentFNT.ScrollIntoView(entry);
         }
 
         private void Button_ExportChangedFNTsClick(object sender, RoutedEventArgs e) {

--- a/ShadowTH Text Editor/MainWindow.xaml.cs
+++ b/ShadowTH Text Editor/MainWindow.xaml.cs
@@ -61,6 +61,8 @@ namespace ShadowTH_Text_Editor {
             Button_OpenAFS.IsEnabled = false;
             Button_ExportAFS.IsEnabled = false;
             Button_ExportChangedFNTs.IsEnabled = false;
+            Button_PreviewADX.IsEnabled = false;
+            Button_AddEntry.IsEnabled = false;
             ClearUIData();
             ListBox_AllFNTS.ItemsSource = null;
             ListBox_CurrentFNT.ItemsSource = null;
@@ -73,6 +75,7 @@ namespace ShadowTH_Text_Editor {
             TextBlock_AfsAudioIDName.Text = "";
             TextBox_AudioID.Clear();
             TextBox_SubtitleActiveTime.Clear();
+            Button_DeleteEntry.IsEnabled = false;
         }
 
         private void ListBox_OpenedFNTS_SelectionChanged(object sender, SelectionChangedEventArgs e) {
@@ -100,6 +103,7 @@ namespace ShadowTH_Text_Editor {
                 ClearUIData();
                 return;
             }
+            Button_DeleteEntry.IsEnabled = true;
             var audioID = currentFnt.GetEntryAudioID(currentSubtitleIndex);
 
             TextBlock_SubtitleAddress.Text = currentFnt.GetEntrySubtitleAddress(currentSubtitleIndex).ToString();
@@ -286,11 +290,12 @@ namespace ShadowTH_Text_Editor {
 
         private void Button_About_Click(object sender, RoutedEventArgs e) {
             MessageBox.Show("Created by dreamsyntax\n" +
-                ".fnt struct reversal done by LimblessVector\n" +
+                ".fnt struct reversal done by LimblessVector & dreamsyntax\n" +
                 ".met/.txd universal map and design work by TheHatedGravity\n" +
                 "Uses AFSLib by Sewer56 for AFS support\n" +
+                "Uses VGAudio by Alex Barney for ADX playback\n" + 
                 "Uses Ookii.Dialogs for dialogs\n\n" +
-                "https://github.com/ShadowTheHedgehogHacking\n\nto check for updates for this software.", "About ShadowTH Text Editor / FNT Editor v1.3");
+                "https://github.com/ShadowTheHedgehogHacking\n\nto check for updates for this software.", "About ShadowTH Text Editor / FNT Editor v1.4");
         }
 
         private void ComboBox_LocaleSwitcher_SelectionChanged(object sender, SelectionChangedEventArgs e) {
@@ -307,13 +312,17 @@ namespace ShadowTH_Text_Editor {
         }
 
         private void TextBox_AddEntryMessageID_TextChanged(object sender, TextChangedEventArgs e) {
-            if (TextBox_AddEntryMessageID.Text == "")
-                AddEntry_Button.IsEnabled = false;
-            else
-                AddEntry_Button.IsEnabled = true;
+            if (TextBox_AddEntryMessageID.Text == "") {
+                TextBlock_AddEntryHint.Visibility = Visibility.Visible;
+                Button_AddEntry.IsEnabled = false;
+            } else {
+                TextBlock_AddEntryHint.Visibility = Visibility.Hidden;
+                if (initialFntsOpenedState != null)
+                    Button_AddEntry.IsEnabled = true;
+            }
         }
 
-        private void AddEntry_Button_Click(object sender, RoutedEventArgs e) {
+        private void Button_AddEntry_Click(object sender, RoutedEventArgs e) {
             int result = currentFnt.InsertNewEntry(int.Parse(TextBox_AddEntryMessageID.Text));
             displayTableListView.Refresh();
             if (result == -1) {
@@ -323,8 +332,15 @@ namespace ShadowTH_Text_Editor {
             }
         }
 
-        private void AddEntry_Question_Button_Click(object sender, RoutedEventArgs e) {
+        private void Button_AddEntry_Question_Click(object sender, RoutedEventArgs e) {
             MessageBox.Show("Add a new entry to a fnt.\n\nSpecify the Message ID / Branch / Sequence int to automatically assign the proper position in the fnt.\nAllows for chaining subtitles/audio by adding +1 to an existing number.\n\nDo not add prior to the first or after the last entry in a fnt.\n\nFormat: XYZ\n    X=Message ID\n    Y=Branch\n    Z=Sequence\n\nExample: 25101\nMessage ID = 25\nBranch = 1 (Normal)\nSequence = 01 (second entry in a chain)\n\nExample branch:\n25000 = Dark\n25100 = Normal\n25200 = Hero\n\nExample sequence:\n25100 = first entry\n25101 = second entry");
+        }
+
+        private void Button_DeleteEntry_Click(object sender, RoutedEventArgs e) {
+            currentFnt.DeleteEntry(currentFnt.entryTable.IndexOf((TableEntry)ListBox_CurrentFNT.SelectedItem));
+            ListBox_CurrentFNT.SelectedIndex = -1;
+            UpdateDisplayTableListView();
+            Button_ExportChangedFNTs.IsEnabled = true;
         }
 
         private void Button_ExportChangedFNTsClick(object sender, RoutedEventArgs e) {

--- a/ShadowTH Text Editor/MainWindow.xaml.cs
+++ b/ShadowTH Text Editor/MainWindow.xaml.cs
@@ -114,14 +114,17 @@ namespace ShadowTH_Text_Editor {
                 TextBlock_AfsAudioIDName.Text = "AFS not loaded";
                 Button_ExtractADX.IsEnabled = false;
                 Button_ReplaceADX.IsEnabled = false;
+                Button_PreviewADX.IsEnabled = false;
             } else if (audioID != -1 && audioID < currentAfs.Files.Count) {
                 TextBlock_AfsAudioIDName.Text = currentAfs.Files[audioID].Name;
                 Button_ExtractADX.IsEnabled = true;
                 Button_ReplaceADX.IsEnabled = true;
+                Button_PreviewADX.IsEnabled = true;
             } else {
                 TextBlock_AfsAudioIDName.Text = "None";
                 Button_ExtractADX.IsEnabled = false;
                 Button_ReplaceADX.IsEnabled = false;
+                Button_PreviewADX.IsEnabled = false;
             }
         }          
 
@@ -260,6 +263,25 @@ namespace ShadowTH_Text_Editor {
             if (dialog.FileName != "") {
                 File.WriteAllBytes(dialog.FileName, currentAfs.Files[int.Parse(TextBox_AudioID.Text)].Data);
             }
+        }
+
+        private void Button_PreviewADXClick(object sender, RoutedEventArgs e) {
+            if (currentAfs == null)
+                return;
+            var audioId = currentFnt.GetEntryAudioID(currentFnt.entryTable.IndexOf((TableEntry)ListBox_CurrentFNT.SelectedItem));
+            if (audioId == -1)
+                return;
+
+            var decoder = new VGAudio.Containers.Adx.AdxReader();
+            var audio = decoder.Read(currentAfs.Files[audioId].Data);
+            var writer = new VGAudio.Containers.Wave.WaveWriter();
+            MemoryStream stream = new MemoryStream();
+            writer.WriteToStream(audio, stream);
+
+            var player = new System.Media.SoundPlayer();
+            stream.Position = 0;
+            player.Stream = stream;
+            player.Play();
         }
 
         private void Button_About_Click(object sender, RoutedEventArgs e) {

--- a/ShadowTH Text Editor/ShadowTH Text Editor.csproj
+++ b/ShadowTH Text Editor/ShadowTH Text Editor.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="AFSLib" Version="1.0.0" />
     <PackageReference Include="Ookii.Dialogs.Wpf.NETCore" Version="2.1.0" />
+    <PackageReference Include="VGAudio" Version="2.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShadowFNT\ShadowFNT.csproj" />


### PR DESCRIPTION
* Determined old implementation of add was faulty (struct size was ignored, was actually overwriting the final entry)
* Corrected add to properly add to struct total
* Add delete feature
* Cleanup UI for delete/add
* Add Goto Selected button to clear filters and snap to selected subtitle
* Add AFS Preview button for real-time audio playback without extracting (VGAudio)
